### PR TITLE
use single info point that is extendable

### DIFF
--- a/example/lib/data.dart
+++ b/example/lib/data.dart
@@ -1126,10 +1126,6 @@ List<List<double>> raw = [
   [5.38825, 45.17357, 208]
 ];
 
-List<LatLng> getPoints() {
-  return raw.map((e) => LatLng(e[1], e[0])).toList();
-}
-
-List<ElevationPoint> getElevationPoints() {
-  return raw.map((e) => ElevationPoint(LatLng(e[1], e[0]), e[2])).toList();
+List<InfoPoint> getPoints() {
+  return raw.map((e) => InfoPoint(e[1], e[0], e[2])).toList();
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -55,7 +55,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  LatLng hoverPoint;
+  InfoPoint hoverPoint;
 
   @override
   Widget build(BuildContext context) {
@@ -114,16 +114,16 @@ class _MyHomePageState extends State<MyHomePage> {
           height: 120,
           child: Container(
             color: Colors.white.withOpacity(0.6),
-            child: NotificationListener<ElevationHoverNotification>(
-                onNotification: (ElevationHoverNotification notification) {
+            child: NotificationListener<InfoHoverNotification>(
+                onNotification: (InfoHoverNotification notification) {
                   setState(() {
-                    hoverPoint = notification.position;
+                    hoverPoint = notification.infoPoint;
                   });
 
                   return true;
                 },
                 child: Elevation(
-                  getElevationPoints(),
+                  getPoints(),
                   color: Colors.grey,
                   elevationGradientColors: ElevationGradientColors(
                       gt10: Colors.green,

--- a/lib/map_elevation.dart
+++ b/lib/map_elevation.dart
@@ -11,7 +11,7 @@ import 'package:latlong/latlong.dart' as lg;
 class Elevation extends StatefulWidget {
   /// List of points to draw on elevation widget
   /// Lat and Long are required to emit notification on hover
-  final List<ElevationPoint> points;
+  final List<InfoPoint> points;
 
   /// Background color of the elevation graph
   final Color color;
@@ -44,11 +44,10 @@ class _ElevationState extends State<Elevation> {
           lbPadding: _lbPadding);
       return GestureDetector(
           onHorizontalDragUpdate: (DragUpdateDetails details) {
-            ElevationPoint pointFromPosition = elevationPainter
+            InfoPoint pointFromPosition = elevationPainter
                 .getPointFromPosition(details.globalPosition.dx);
-            if (pointFromPosition is ElevationPoint) {
-              ElevationHoverNotification(pointFromPosition.latLng)
-                ..dispatch(context);
+            if (pointFromPosition is InfoPoint) {
+              InfoHoverNotification(pointFromPosition)..dispatch(context);
               setState(() {
                 _hoverLinePosition = details.globalPosition.dx;
                 _hoveredAltitude = pointFromPosition.altitude;
@@ -56,7 +55,7 @@ class _ElevationState extends State<Elevation> {
             }
           },
           onHorizontalDragEnd: (DragEndDetails details) {
-            ElevationHoverNotification(null)..dispatch(context);
+            InfoHoverNotification(null)..dispatch(context);
             setState(() {
               _hoverLinePosition = null;
             });
@@ -102,7 +101,7 @@ class _ElevationState extends State<Elevation> {
 }
 
 class _ElevationPainter extends CustomPainter {
-  List<ElevationPoint> points;
+  List<InfoPoint> points;
   List<double> _relativeAltitudes;
   Color paintColor;
   Offset lbPadding;
@@ -161,8 +160,7 @@ class _ElevationPainter extends CustomPainter {
     if (elevationGradientColors is ElevationGradientColors) {
       List<Color> gradientColors = [paintColor];
       for (int i = 1; i < points.length; i++) {
-        double dX =
-            lg.Distance().distance(points[i].latLng, points[i - 1].latLng);
+        double dX = lg.Distance().distance(points[i], points[i - 1]);
         double dZ = (points[i].altitude - points[i - 1].altitude);
 
         double gradient = 100 * dZ / dX;
@@ -230,7 +228,7 @@ class _ElevationPainter extends CustomPainter {
   double _getYForAltitude(double altitude, Size size) =>
       size.height - altitude * size.height - lbPadding.dy;
 
-  ElevationPoint getPointFromPosition(double position) {
+  InfoPoint getPointFromPosition(double position) {
     int index = ((position - lbPadding.dx) / widthOffset).round();
 
     if (index >= points.length || index < 0) return null;
@@ -246,11 +244,11 @@ class _ElevationPainter extends CustomPainter {
 }
 
 /// [Notification] emitted when graph is hovered
-class ElevationHoverNotification extends Notification {
-  /// Hovered point coordinates
-  final lg.LatLng position;
+class InfoHoverNotification extends Notification {
+  /// Hovered point
+  final InfoPoint infoPoint;
 
-  ElevationHoverNotification(this.position);
+  InfoHoverNotification(this.infoPoint);
 }
 
 /// Elevation gradient colors
@@ -269,12 +267,10 @@ class ElevationGradientColors {
 }
 
 /// Geographic point with elevation
-class ElevationPoint {
-  /// Latitude and Longitude
-  lg.LatLng latLng;
-
+class InfoPoint extends lg.LatLng {
   /// Altitude (in meters)
   double altitude;
 
-  ElevationPoint(this.latLng, this.altitude);
+  InfoPoint(double latitude, double longitude, this.altitude)
+      : super(latitude, longitude);
 }


### PR DESCRIPTION
Hi @tuarrep , thanks for this amazing plugin, I love it :-)

In this pull request I would like to make a proposal to use hoverpoints that:

* extend LatLng so that the point list can be used both in the polyline and in the Elevation
* change the ElevationHoverNotification to a InfoHoverNotification, and pass that as hover notification instead of only the coordinate. That would allow to extend that InfoPoint and pass through it also other information like progressive distance, speed and timestamp.

I hope you like the idea.
