### PR TITLE
This PR allows to upgrade flutter map to the last version

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong/latlong.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:map_elevation/map_elevation.dart';
 
 import 'data.dart';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,8 +23,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^0.10.1
-  latlong: ^0.6.1
+  flutter_map: ^0.13.1
+  latlong2: ^0.8.0
   map_elevation:
     path: ../
 

--- a/lib/map_elevation.dart
+++ b/lib/map_elevation.dart
@@ -5,7 +5,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:latlong/latlong.dart' as lg;
+import 'package:latlong2/latlong.dart' as lg;
 
 /// Elevation statefull widget
 class Elevation extends StatefulWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  latlong: ^0.6.1
+  latlong2: ^0.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Basically it uses the latlong2 lib to substitute the latlong one. 
Example works with flutter_map 0.13.1